### PR TITLE
By default, select the view named 'All' instead of first view

### DIFF
--- a/iJenkins/FTServerHomeViewController.m
+++ b/iJenkins/FTServerHomeViewController.m
@@ -90,7 +90,21 @@
                 
                 if (_serverObject.views.count > 1) {
                     if (!_selectedView) {
-                        _selectedView = [_views objectAtIndex:0];
+                        // Select the view named 'All'
+                        
+                        // Array with all localizations of 'All' (en, da/de/nl, es, fr, ja, ru, zh_TW, it, pt_BR, tr)
+                        NSArray *allNames = @[@"All", @"Alle", @"Todo", @"Tous", @"\u3059\u3079\u3066", @"\u0412\u0441\u0435", @"\u5168\u90e8", @"Tutto", @"Tudo", @"Hepsi"];
+                        
+                        for (FTAPIServerViewDataObject *v in _views) {
+                            if ([allNames containsObject:v.name]) {
+                                _selectedView=v;
+                                break;
+                            }
+                        }
+                        if (!_selectedView) {
+                            // No view named 'All' found, fall back to first view in the list
+                            _selectedView = [_views objectAtIndex:0];
+                        }
                     }
                 }
                 


### PR DESCRIPTION
By default select the view named 'All' (or any translation of that). Fixes issue #42 (When you have a view that is alphabetically before 'All', iJenkins loads in a weird state).

I got the translation strings for 'All' from the jenkins repository, the files Messages*.properties at https://github.com/jenkinsci/jenkins/tree/master/core/src/main/resources/jenkins/model contain the translated string for the key `Hudson.ViewName`.